### PR TITLE
Wii,GC: increase options in main menu

### DIFF
--- a/Trogdor-Reburninated/src/menu.h
+++ b/Trogdor-Reburninated/src/menu.h
@@ -7,7 +7,7 @@
 #define MENU_H
 
 constexpr auto MAX_NUM_OPTION_CHOICES = 23;
-constexpr auto MAX_NUM_MENU_OPTIONS = 9;
+constexpr auto MAX_NUM_MENU_OPTIONS = 10;
 constexpr auto MAX_NUM_MENU_PAGES = 7;
 constexpr auto MAX_NUM_MENU_LINES = 12;
 


### PR DESCRIPTION
The Wii and GameCube have one more option than other platforms, so in their case the maximum number is 10, not 9. This was causing a buffer overflow.

I haven't tried this on the Wii yet, but it fixes the warnings in Dolphin at least.