### PR TITLE
Migrate GameCube port to libogc2

### DIFF
--- a/Trogdor-Reburninated/Makefiles/Makefile_gc
+++ b/Trogdor-Reburninated/Makefiles/Makefile_gc
@@ -14,7 +14,7 @@ ifeq ($(strip $(DEVKITPPC)),)
 $(error "Please set DEVKITPPC in your environment. export DEVKITPPC=<path to>devkitPPC")
 endif
 
-include $(DEVKITPPC)/gamecube_rules
+include $(DEVKITPRO)/libogc2/gamecube_rules
 
 #---------------------------------------------------------------------------------
 # TARGET is the name of the output
@@ -33,7 +33,7 @@ INCLUDES	:=	src src/fonts_h src/graphics_h src/graphics_h/backgrounds src/graphi
 # options for code generation
 #---------------------------------------------------------------------------------
 
-CFLAGS	= `$(PREFIX)pkg-config --cflags sdl2 SDL2_ttf SDL2_gfx SDL2_mixer SDL2_image freetype2` -g -O2 -Wall $(MACHDEP) $(INCLUDE) -DGAMECUBE -DNINTENDO_LAYOUT -DOGG_SFX
+CFLAGS	= `$(PREFIX)pkg-config --cflags sdl2 SDL2_ttf SDL2_gfx SDL2_mixer SDL2_image` -g -O2 -Wall $(MACHDEP) $(INCLUDE) -DGAMECUBE -DNINTENDO_LAYOUT -DOGG_SFX
 CXXFLAGS	=	$(CFLAGS)
 
 LDFLAGS	=	-g $(MACHDEP) -Wl,-Map,$(notdir $@).map
@@ -41,13 +41,13 @@ LDFLAGS	=	-g $(MACHDEP) -Wl,-Map,$(notdir $@).map
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project
 #---------------------------------------------------------------------------------
-LIBS	:=	`$(PREFIX)pkg-config --libs sdl2 SDL2_ttf SDL2_gfx SDL2_mixer SDL2_image freetype2` -lfat -logc -lm -lopus
+LIBS	:=	`$(PREFIX)pkg-config --libs sdl2 SDL2_ttf SDL2_gfx SDL2_mixer SDL2_image` -lfat -logc -lm
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing
 # include and lib
 #---------------------------------------------------------------------------------
-LIBDIRS := "$(DEVKITPRO)/portlibs/ppc" "$(DEVKITPRO)/portlibs/gamecube"
+LIBDIRS	:= $(PORTLIBS)
 
 #---------------------------------------------------------------------------------
 # no real need to edit anything past this point unless you need to add additional

--- a/Trogdor-Reburninated/src/config.cpp
+++ b/Trogdor-Reburninated/src/config.cpp
@@ -43,7 +43,7 @@ string getExeDirectory() {
 #endif
 }
 
-#if defined(GAMECUBE) || defined(LINUX)
+#if defined(LINUX)
 static bool directoryExists(const std::string &path) {
 	struct stat info;
 	if (stat(path.c_str(), &info) != 0) {
@@ -60,13 +60,7 @@ void setRootDir() {
 #elif defined(WII)
 	rootDir = "sd:/apps/Trogdor-RB/";
 #elif defined(GAMECUBE)
-	string devices[] = {"sda", "sdb", "sdc"};
-	for (const auto& device : devices) {
-		rootDir = device + ":/Trogdor-RB/";
-		if (directoryExists(rootDir)) {
-			break;
-		}
-	}
+	rootDir = "/Trogdor-RB/";
 #elif defined(THREEDS)
 	rootDir = "sdmc:/3ds/Trogdor-RB/";
 #elif defined(_WIN32)

--- a/Trogdor-Reburninated/src/general.cpp
+++ b/Trogdor-Reburninated/src/general.cpp
@@ -69,50 +69,6 @@ void applyColorKey(SDL_Surface *surface, bool isTransparent) {
 	}
 }
 
-#if defined(GAMECUBE)
-#define DEV_GCSDA 	  1
-#define DEV_GCSDB 	  2
-#define DEV_GCSDC 	  3
-
-static bool gc_initFAT(int device)
-{
-	switch (device) {
-	case DEV_GCSDA:
-		__io_gcsda.startup();
-		if (!__io_gcsda.isInserted()) {
-			return false;
-		}
-		if (!fatMountSimple("sda", &__io_gcsda)) {
-			return false;
-		}
-		break;
-	case DEV_GCSDB:
-		__io_gcsdb.startup();
-		if (!__io_gcsdb.isInserted()) {
-			return false;
-		}
-		if (!fatMountSimple("sdb", &__io_gcsdb)) {
-			return false;
-		}
-		break;
-	case DEV_GCSDC:
-		__io_gcsd2.startup();
-		if (!__io_gcsd2.isInserted()) {
-			return false;
-		}
-		if (!fatMountSimple("sdc", &__io_gcsd2)) {
-			return false;
-		}
-		break;
-	default:
-		return false;
-		break;
-	}
-
-	return true;
-}
-#endif
-
 void systemSpecificOpen() {
 #if defined(WII_U)
 	/* Set SD Card Mount Path */
@@ -129,17 +85,10 @@ void systemSpecificOpen() {
 #elif defined(SWITCH)
 	/* Set SD Card mount path */
 	chdir("/switch/Trogdor-RB");
-#elif defined(WII)
+#elif defined(WII) || defined(GAMECUBE)
 	/* Initialize SD Card */
 	fatInitDefault();
 	/* Initialize Controller */
-	PAD_Init();
-#elif defined(GAMECUBE)
-	for (int i = 1; i < 4; i++) {
-		if (gc_initFAT(i)) {
-			break;
-		}
-	}
 	PAD_Init();
 #elif defined(XBOX)
 	XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);

--- a/Trogdor-Reburninated/src/include.h
+++ b/Trogdor-Reburninated/src/include.h
@@ -57,8 +57,6 @@
 #include <ogc/pad.h>
 #include <dirent.h>
 #include <fat.h>
-#include <sys/stat.h>
-#include <sdcard/gcsd.h>
 #elif defined(PSP)
 #include <pspkernel.h>
 #include <pspdebug.h>


### PR DESCRIPTION
This adds support for the following:
* exFAT filesystem and GPT partitioning
* CUBEODE and GC Loader
* MMCE (FlipperMCE, GCMCE and MemCard PRO GC)
* Semi-passive SD card adapters (GC2SD Gen2, SD2SP2 2.0, etc.)
* Combo SD card adapters (future products)
* SD2SP1
* Return to loader (Swiss)
* Possibly more, I forget

This also fixes:
* Progressive scan mode being forcibly enabled when using component video
* Compatibility with various SD cards
* Possibly more, I forget

Required packages from [extremscorner/pacman-packages](https://github.com/extremscorner/pacman-packages):
* `libogc2-git`
* `libogc2-libdvm-git`
* `libogc2-pkg-config`
* `libogc2-sdl2`
* `libogc2-sdl2_gfx`
* `libogc2-sdl2_image`
* `libogc2-sdl2_mixer`
* `libogc2-sdl2_ttf`